### PR TITLE
cve severity

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,4 @@ RUN apk --no-cache --virtual .build-dependencies add git \
 WORKDIR /
 
 EXPOSE 8080
-CMD [ "/concordance-rw-dynamodb" ]
+CMD [ "/coreos-version-checker" ]

--- a/main.go
+++ b/main.go
@@ -37,6 +37,7 @@ func main() {
 	})
 
 	app.Action = func() {
+		log.SetFormatter(log.JSONFormatter{})
 		log.WithField("update-conf", *coreOSUpdateConfPath).WithField("release-conf", *coreOSReleaseConfPath).Info("Started with provided config.")
 
 		client := &http.Client{Timeout: 1500 * time.Millisecond}

--- a/main.go
+++ b/main.go
@@ -37,7 +37,7 @@ func main() {
 	})
 
 	app.Action = func() {
-		log.SetFormatter(log.JSONFormatter{})
+		log.SetFormatter(&log.JSONFormatter{})
 		log.WithField("update-conf", *coreOSUpdateConfPath).WithField("release-conf", *coreOSReleaseConfPath).Info("Started with provided config.")
 
 		client := &http.Client{Timeout: 1500 * time.Millisecond}

--- a/util.go
+++ b/util.go
@@ -37,6 +37,8 @@ func GetJSON(client httpClient, uri string) (map[string]interface{}, error) {
 		return nil, err
 	}
 
+	defer resp.Body.Close()
+
 	dec := json.NewDecoder(resp.Body)
 	data := make(map[string]interface{})
 


### PR DESCRIPTION
Checks various CVE security levels for a new coreOS release and responds with different healthcheck severity levels

fixes from this PR: https://github.com/Financial-Times/coreos-version-checker/pull/3